### PR TITLE
fix(link): add href to storybook docs to add focus state and remove t…

### DIFF
--- a/src/lib/components/Link/Link.stories.tsx
+++ b/src/lib/components/Link/Link.stories.tsx
@@ -7,6 +7,9 @@ const meta = {
   parameters: {
     layout: "centered",
   },
+  args: {
+    href: "#",
+  },
   argTypes: {
     children: {
       description: "The content of the link.",

--- a/src/lib/components/Link/Link.tsx
+++ b/src/lib/components/Link/Link.tsx
@@ -7,6 +7,7 @@ const StyledLink = styled.a<LinkProps>`
   font-size: 14px;
   font-weight: 700;
   color: ${({ theme }) => theme.colors.primary.main};
+  text-decoration: none;
 
   cursor: default;
   border-radius: 4px;
@@ -19,9 +20,6 @@ const StyledLink = styled.a<LinkProps>`
   &:focus,
   &:active {
     background-color: ${({ theme }) => theme.colors.background.light[500]};
-  }
-
-  &:focus {
     outline: none;
   }
 `;


### PR DESCRIPTION
re #27
# Changes:
- Remove the underline from the link.
- Pass `href` on storybook demo.