### PR TITLE
ci(tests and linting): add types check and eslint linting job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: Testing and Linting
 on:
   push:
     branches:
@@ -23,3 +23,20 @@ jobs:
         run: pnpm install
       - name: Run unit tests 🚧
         run: pnpm vitest --run
+  linting:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: pnpm/action-setup@v2.4.0
+      - name: Cache node_modules 📁
+        uses: actions/cache@v3
+        id: cache-primes
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Install dependencies 📥
+        if: steps.cache-primes.outputs.cache-hit != 'true'
+        run: pnpm install
+      - name: Run linting ✍️
+        run: pnpm lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,24 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+set -e
+
 # Run scripts on changed files
-pnpm lint-staged
+echo -e "🏃 Running pre-commit checks"
+
+# Check if there are any staged files
+staged_files=$(git diff --cached --name-only)
+if [ -n "$staged_files" ]; then
+
+  # Lint staged
+  echo -e "\033[32m>\033[0m Running lint on staged files"
+  pnpm lint-staged
+
+  # Type checks
+  echo -e "\033[32m>\033[0m Running types check"
+  node .husky/scripts/types-check.js
+
+else echo -e "\033[34m→\033[0m No staged files found."
+fi
+
+echo -e "✅ Your commit is now ready! \033[32m↓\033[0m"

--- a/.husky/scripts/types-check.js
+++ b/.husky/scripts/types-check.js
@@ -1,0 +1,42 @@
+import ora from "ora";
+import { exec } from "child_process";
+
+exec("git diff --cached --name-only -- '*.ts' '*.tsx'", (_, stdout) => {
+  // Split the output by line breaks and count the lines
+  const stagedFiles = stdout.split("\n").filter(Boolean);
+  const numberOfStagedFiles = stagedFiles.length;
+
+  if (numberOfStagedFiles === 0) {
+    // No staged files found
+    console.log("\x1b[34m→\x1b[0m No staged files match any configured task.");
+    process.exit(0);
+  }
+
+  const typeChecksCommand = "pnpm tsc --noEmit --pretty";
+
+  const spinner = ora({
+    text: typeChecksCommand,
+    color: "yellow",
+  });
+
+  spinner.start();
+
+  // Run type checks
+  const childProcess = exec(typeChecksCommand, (err, stdout) => {
+    // On fails the code is 2 and the stdout contains the error
+    if (err.code === 2 && stdout) {
+      console.log(stdout);
+      process.exit(1);
+    }
+  });
+
+  // Change the spinner on exit
+  childProcess.on("exit", code => {
+    if (code === 0) {
+      // Type checks completed successfully
+      spinner.succeed("Type checks successful!");
+    }
+    // Type checks failed
+    spinner.fail("Type checks failed.");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "husky": "^8.0.0",
     "jsdom": "^22.1.0",
     "lint-staged": "^14.0.1",
+    "ora": "^7.0.1",
     "playwright": "^1.38.0",
     "prettier": "^3.0.3",
     "storybook": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "tsc --noEmit && eslint --ext .js,.ts,.jsx,.tsx --report-unused-disable-directives --max-warnings 0 src/",
     "test": "vitest",
     "preview": "vite preview",
     "storybook:dev": "storybook dev -p 6006",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ specifiers:
   husky: ^8.0.0
   jsdom: ^22.1.0
   lint-staged: ^14.0.1
+  ora: ^7.0.1
   playwright: ^1.38.0
   prettier: ^3.0.3
   react: ^18.2.0
@@ -86,6 +87,7 @@ devDependencies:
   husky: 8.0.3
   jsdom: 22.1.0
   lint-staged: 14.0.1
+  ora: 7.0.1
   playwright: 1.38.0
   prettier: 3.0.3
   storybook: 7.2.2
@@ -7049,6 +7051,17 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
+  /bl/5.1.0:
+    resolution:
+      {
+        integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==,
+      }
+    dependencies:
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    dev: true
+
   /body-parser/1.20.1:
     resolution:
       {
@@ -7168,6 +7181,16 @@ packages:
     resolution:
       {
         integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: true
+
+  /buffer/6.0.3:
+    resolution:
+      {
+        integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==,
       }
     dependencies:
       base64-js: 1.5.1
@@ -8524,6 +8547,13 @@ packages:
         integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==,
       }
     engines: { node: ">=12" }
+    dev: true
+
+  /emoji-regex/10.2.1:
+    resolution:
+      {
+        integrity: sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==,
+      }
     dev: true
 
   /emoji-regex/8.0.0:
@@ -10508,6 +10538,14 @@ packages:
     engines: { node: ">=8" }
     dev: true
 
+  /is-interactive/2.0.0:
+    resolution:
+      {
+        integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==,
+      }
+    engines: { node: ">=12" }
+    dev: true
+
   /is-map/2.0.2:
     resolution:
       {
@@ -10697,6 +10735,14 @@ packages:
         integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==,
       }
     engines: { node: ">=10" }
+    dev: true
+
+  /is-unicode-supported/1.3.0:
+    resolution:
+      {
+        integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==,
+      }
+    engines: { node: ">=12" }
     dev: true
 
   /is-utf8/0.2.1:
@@ -12064,6 +12110,17 @@ packages:
       is-unicode-supported: 0.1.0
     dev: true
 
+  /log-symbols/5.1.0:
+    resolution:
+      {
+        integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==,
+      }
+    engines: { node: ">=12" }
+    dependencies:
+      chalk: 5.3.0
+      is-unicode-supported: 1.3.0
+    dev: true
+
   /log-update/5.0.1:
     resolution:
       {
@@ -12920,6 +12977,24 @@ packages:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
+    dev: true
+
+  /ora/7.0.1:
+    resolution:
+      {
+        integrity: sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==,
+      }
+    engines: { node: ">=16" }
+    dependencies:
+      chalk: 5.3.0
+      cli-cursor: 4.0.0
+      cli-spinners: 2.9.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 1.3.0
+      log-symbols: 5.1.0
+      stdin-discarder: 0.1.0
+      string-width: 6.1.0
+      strip-ansi: 7.1.0
     dev: true
 
   /os-homedir/1.0.2:
@@ -14668,6 +14743,16 @@ packages:
       }
     dev: true
 
+  /stdin-discarder/0.1.0:
+    resolution:
+      {
+        integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      bl: 5.1.0
+    dev: true
+
   /stop-iteration-iterator/1.0.0:
     resolution:
       {
@@ -14758,6 +14843,18 @@ packages:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+    dev: true
+
+  /string-width/6.1.0:
+    resolution:
+      {
+        integrity: sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==,
+      }
+    engines: { node: ">=16" }
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 10.2.1
       strip-ansi: 7.1.0
     dev: true
 

--- a/src/lib/components/Avatar/Avatar.test.tsx
+++ b/src/lib/components/Avatar/Avatar.test.tsx
@@ -3,7 +3,7 @@ import { Avatar } from ".";
 import { act } from "react-dom/test-utils";
 
 describe("Avatar", () => {
-  test("Should render with required propertues", () => {
+  test("Should render with required properties", () => {
     const { getByText } = render(<Avatar initials="HR" size="small" />);
     expect(getByText("HR")).toBeInTheDocument();
   });
@@ -11,7 +11,7 @@ describe("Avatar", () => {
   test("Should display image when valid image url passed", async () => {
     const url =
       "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcR6q1sSJClIv9OuONIcOpFFQUAlbIr6g94oMgsYZp58wkIjaXGF";
-    const { getByRole } = render(<Avatar initials="" image={url} />);
+    const { getByRole } = render(<Avatar image={url} />);
 
     const img = getByRole("img", { hidden: true });
     act(() => {
@@ -23,17 +23,20 @@ describe("Avatar", () => {
 
   test("Should display initials when invalid image url passed", async () => {
     const url = "https://some-invalid-url/img.jpg";
-    const { getByRole } = render(<Avatar initials="" image={url} />);
+    const { getByRole, getByText } = render(
+      <Avatar initials="INITIALS" image={url} />,
+    );
 
     const img = getByRole("img", { hidden: true });
     act(() => {
       fireEvent.error(img);
     });
     expect(img).toHaveStyle({ display: "none" });
+    expect(getByText("INITIALS")).toBeInTheDocument();
   });
 
   test("Should display status indication when status provided", () => {
-    const { getByRole } = render(<Avatar initials="" status="active" />);
+    const { getByRole } = render(<Avatar status="active" />);
     expect(getByRole("status")).toBeInTheDocument();
   });
 
@@ -41,9 +44,7 @@ describe("Avatar", () => {
     const url =
       "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcR6q1sSJClIv9OuONIcOpFFQUAlbIr6g94oMgsYZp58wkIjaXGF";
     const altText = "Daniel's avatar";
-    const { getByRole } = render(
-      <Avatar initials="" image={url} alt={altText} />
-    );
+    const { getByRole } = render(<Avatar image={url} alt={altText} />);
 
     const img = getByRole("img", { hidden: true });
     act(() => {

--- a/src/lib/components/Avatar/Avatar.tsx
+++ b/src/lib/components/Avatar/Avatar.tsx
@@ -7,9 +7,9 @@ type AvatarStatus = "active" | "inactive";
 export interface AvatarProps {
   initials: string;
   size: AvatarSizes;
-  image?: string;
-  alt?: string;
-  status?: AvatarStatus;
+  image: string;
+  alt: string;
+  status: AvatarStatus;
 }
 
 const sizes: { [key in AvatarSizes]: string } = {
@@ -75,7 +75,7 @@ export function Avatar({
   image,
   alt = "avatar",
   status,
-}: AvatarProps) {
+}: Partial<AvatarProps>) {
   const [isImageLoaded, setIsImageLoaded] = useState(false);
 
   const handleImageLoad = () => {


### PR DESCRIPTION
Related to #41 

# Changes:
- Add type-check to the `lint` script.
- Configure eslint config in the `lint` script.
- Add a new listing job to the `tests` workflow.
- Add types check to pre-commit hook.
