### PR TITLE
fix(types-check.js): fix type error non type check run

### DIFF
--- a/.husky/scripts/types-check.js
+++ b/.husky/scripts/types-check.js
@@ -24,7 +24,7 @@ exec("git diff --cached --name-only -- '*.ts' '*.tsx'", (_, stdout) => {
   // Run type checks
   const childProcess = exec(typeChecksCommand, (err, stdout) => {
     // On fails the code is 2 and the stdout contains the error
-    if (err.code === 2 && stdout) {
+    if (err && err.code === 2 && stdout) {
       console.log(stdout);
       process.exit(1);
     }
@@ -35,8 +35,9 @@ exec("git diff --cached --name-only -- '*.ts' '*.tsx'", (_, stdout) => {
     if (code === 0) {
       // Type checks completed successfully
       spinner.succeed("Type checks successful!");
+    } else {
+      // Type checks failed
+      spinner.fail("Type checks failed.");
     }
-    // Type checks failed
-    spinner.fail("Type checks failed.");
   });
 });


### PR DESCRIPTION
Type check resulted in a type error due to the err variable being null when the execution of typeCheckCommand is successful.

BREAKING CHANGE: types-check.js changes

Related to #41 comment: https://github.com/daniknewgarden/exo-ui/issues/41#issuecomment-1747639743

# Changes:
- Refactor type-check precommit script.
  - In case if the error is `null`.

